### PR TITLE
Change bg_visual for zen mode to be also inkBlack3

### DIFF
--- a/lua/kanso/themes.lua
+++ b/lua/kanso/themes.lua
@@ -118,7 +118,7 @@ return {
                 whitespace                       = palette.inkBlack0,
                 nontext                          = palette.inkAsh,
 
-                bg_visual                        = palette.inkBlack2,
+                bg_visual                        = palette.inkBlack3,
                 bg_search                        = palette.zenBlue2,
 
                 cursor_line_nr_foreground        = palette.inkGray3,


### PR DESCRIPTION
After testing, the contrast is too low when the selection is small, proving difficult to identify where the selection starts and ends. I believe while in visual mode, usually it is most important to easily locate the start/end of the visual block even if it results in a small sacrifice in legibility of the selected content given the fact that it is usually meant to serve as visual guidelines for an operation on the text.

This is also based on the fact that `ink` variant already uses `inkBlack3` and the contrast on the light theme is also quite sufficient.

Here are before/after screenshots for comparison:
<img width="509" alt="image" src="https://github.com/user-attachments/assets/2ac6a513-12f9-4e0d-ba95-b92ee03782a5" />
<img width="512" alt="image" src="https://github.com/user-attachments/assets/86c37eb6-73b9-4b14-a9ad-f4b911cfa5ca" />
