### PR TITLE
Switch cursor foreground and background colors for WezTerm

### DIFF
--- a/extras/wezterm/kanso-ink.lua
+++ b/extras/wezterm/kanso-ink.lua
@@ -4,8 +4,8 @@ local config = {
 		foreground = "#C5C9C7",
 		background = "#14171d",
 
-		cursor_bg = "#14171d",
-		cursor_fg = "#C5C9C7",
+		cursor_bg = "#C5C9C7",
+		cursor_fg = "#14171d",
 		cursor_border = "#C5C9C7",
 
 		selection_fg = "#C5C9C7",


### PR DESCRIPTION
If `force_reverse_video_cursor` is set to false, then the cursor blends in perfectly with the background, making it very hard to see, so the colors for the `cursor_bg` and `cursor_fg` should be switched.

Original (cursor at line 39):
![image](https://github.com/user-attachments/assets/3f57589a-9021-42ad-9672-f521983610b7)

Changed:
![image](https://github.com/user-attachments/assets/70da6695-230e-4938-9ea8-2936f1c617bc)

I would also suggest setting `force_reverse_video_Cursor` to false by default since the cursor can still be hard to see even with this option toggled on.