### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ local palette_colors = colors.palette
 local theme_colors = colors.theme
 
 -- Get the colors for a specific theme
-local zen_colors = require("kanso.colors").setup({ theme = 'ink' })
+local zen_colors = require("kanso.colors").setup({ theme = 'zen' })
 ```
 
 ## 🧩 Extras


### PR DESCRIPTION
In this example code snippet, the variable name was specified as `zen_colors` but the code was extracting the colors for the "ink" palette. Did a simple fix to make the variable name consistent with the code.