### PR TITLE
Differentiate section B in lualine 

### DIFF
--- a/lua/lualine/themes/kanso.lua
+++ b/lua/lualine/themes/kanso.lua
@@ -30,7 +30,7 @@ kanso.replace = {
 
 kanso.inactive = {
     a = { bg = theme.ui.none, fg = theme.ui.fg_dim },
-    b = { bg = theme.ui.bg_p1, fg = theme.ui.fg_dim },
+    b = { bg = theme.ui.none, fg = theme.ui.fg_dim },
     c = { bg = theme.ui.none, fg = theme.ui.fg_dim },
 }
 


### PR DESCRIPTION
Currently, sections B and C in the lualine theme have the same background which makes them look the same. Below is using Ink, where I have the filename in section B and branch in section C:
<img width="500"  alt="kanso-main-branch" src="https://github.com/user-attachments/assets/7c729f17-be0d-45e9-b4b9-9ff2e88a7a1d" />

To provide some contrast, I suggest using one lighter shade lighter than the background (`bg_p1`):

<img width="500" alt="kanso-my-zen" src="https://github.com/user-attachments/assets/bbe842b1-6e2d-4250-9c31-0f4104965af7" />

<img width="500" alt="kanso-my-ink" src="https://github.com/user-attachments/assets/c8500288-addc-484f-b5e0-255ca3125b34" />

<img width="500" alt="kanso-my-mist" src="https://github.com/user-attachments/assets/b15a498a-894f-4f23-ad44-1efc1aa000e7" />

<img width="500" alt="kanso-my-pearl" src="https://github.com/user-attachments/assets/2e13ae13-ec3b-4c48-b326-df483683c18d" />

---
May also close #22 , I was able to replicate the issue in a while with diagnostic problems (my last element in section C) that is fixed by setting the background.

Before:
<img width="500" alt="kanso-issue-before" src="https://github.com/user-attachments/assets/11131406-651b-4f9b-81e9-c77c942d9e3f" />

After:

<img width="500" alt="kanso-issue-after" src="https://github.com/user-attachments/assets/b07dd533-25c8-45e4-a46e-14600d245a64" />

---

Feel free to suggest changes/close this! Thanks for all the work!