### PR TITLE
Fix Blink's border background color when transparency is enabled

### DIFF
--- a/lua/kanso/highlights/plugins.lua
+++ b/lua/kanso/highlights/plugins.lua
@@ -211,7 +211,7 @@ function M.setup(colors, config)
         -- blink.cmp
         BlinkCmpMenu = { link = "Pmenu" },
         BlinkCmpMenuSelection = { link = "PmenuSel" },
-        BlinkCmpMenuBorder = { fg = theme.ui.bg_search, bg = theme.ui.pmenu.bg },
+        BlinkCmpMenuBorder = { fg = theme.ui.bg_search, bg = config.transparent and theme.ui.none or theme.ui.pmenu.bg },
         BlinkCmpScrollBarThumb = { link = "PmenuThumb" },
         BlinkCmpScrollBarGutter = { link = "PmenuSbar" },
         BlinkCmpLabel = { fg = theme.ui.pmenu.fg },


### PR DESCRIPTION
Fixes #34

With `transparency = true`:

<img width="481" height="485" alt="image" src="https://github.com/user-attachments/assets/d246f34c-2885-44da-a1da-41dd519560d4" />

With `transparency = false`:

<img width="490" height="480" alt="image" src="https://github.com/user-attachments/assets/a02536b4-7186-4b5d-9eef-0adc71ace0de" />
